### PR TITLE
Fixed the message queue and hickups

### DIFF
--- a/lib/client/TrovoClient.js
+++ b/lib/client/TrovoClient.js
@@ -71,8 +71,7 @@ module.exports = class Client extends EventEmitter {
       this.viewport = settings.viewport == undefined ? this.viewport : settings.viewport;
     }
     this.page = null;
-    this.queue = new Queue();
-    this.queue.autostart = true;
+    this.queue = new Queue({autostart: true, concurrency: 1});
   }
   async newPage() {
     this.browser = await puppeteer.launch({
@@ -156,9 +155,8 @@ module.exports = class Client extends EventEmitter {
     this.emit("ready");
   }
   sendMessage(message) {
-    this.queue.push(async (cb) => {
-      this._sendMessage(message);
-      cb();
+    this.queue.push(() => {
+      return this._sendMessage(message);
     });
   }
   async _sendMessage(message) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trovo.js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A powerful library for interacting with the Trovo API",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
This should fix the message sending and hickups.

Two problems:
1. In the previous version this._sendMessage was called but the code never waited for it to return.
2. Even if it had waited the queue wouldn't be interested in it because by default it has infinite threads. So all jobs are executed concurrently.

Now the queue only executes a single job at once and the _sendMessage function is waited for.


If this gets merged we can replace all "setTimeout( () => bot.sendMesage("foo"));" with "bot.sendMessage("foo")" :)